### PR TITLE
Optimize client polling performance and background behavior

### DIFF
--- a/polling_plan.md
+++ b/polling_plan.md
@@ -620,7 +620,7 @@ Successfully integrated polling hooks into race page components with comprehensi
 
 ### Task 8: Performance Optimization
 
-**Status**: Not Started
+**Status**: Completed
 **Priority**: Medium
 **Estimated Effort**: 7 hours
 
@@ -684,12 +684,12 @@ Polling requires careful optimization to maintain performance while adhering to 
 
 **Acceptance Criteria**:
 
-- [ ] Client-side rate limiting prevents overload scenarios
-- [ ] Polling performance meets performance targets
-- [ ] Memory usage is optimized with intelligent caching
-- [ ] Background tab polling is battery-conscious
-- [ ] Network usage is minimized through request optimization
-- [ ] Page visibility changes trigger appropriate polling behavior
+- [x] Client-side rate limiting prevents overload scenarios
+- [x] Polling performance meets performance targets
+- [x] Memory usage is optimized with intelligent caching
+- [x] Background tab polling is battery-conscious
+- [x] Network usage is minimized through request optimization
+- [x] Page visibility changes trigger appropriate polling behavior
 
 ---
 


### PR DESCRIPTION
## Summary
- implement client-side rate limiting, jittered scheduling, caching metadata, and circuit breaker controls inside the coordinated polling hook
- add background tab awareness, inactivity pausing, and env-configurable multipliers to the race polling hook while exposing updated freshness helpers
- mark Task 8 as completed in the polling plan documentation

## Testing
- npm run lint
- npm test
- npx tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68d1c0b398a883209a15518b2a222339