### PR TITLE
Implement dynamic polling interval alignment

### DIFF
--- a/client/.env.example
+++ b/client/.env.example
@@ -20,3 +20,11 @@ NEXT_PUBLIC_LOG_LEVEL=ERROR
 
 # Enable 2x polling frequency for race data (default false)
 NEXT_PUBLIC_DOUBLE_POLLING_FREQUENCY=false
+
+# Server-side override for matching master scheduler cadence (optional)
+DOUBLE_POLLING_FREQUENCY=false
+
+# Client polling controls
+NEXT_PUBLIC_POLLING_ENABLED=true
+NEXT_PUBLIC_POLLING_DEBUG_MODE=false
+NEXT_PUBLIC_POLLING_TIMEOUT=10000

--- a/client/src/utils/timezoneUtils.ts
+++ b/client/src/utils/timezoneUtils.ts
@@ -54,12 +54,13 @@ export function getCurrentNzDateString(): string {
 export function getMinutesUntilRaceStart(raceStartTimeIso: string): number | null {
   if (!raceStartTimeIso) return null
 
-  const now = new Date()
-  const raceStart = new Date(raceStartTimeIso)
+  const raceStartTimestamp = Date.parse(raceStartTimeIso)
+  if (Number.isNaN(raceStartTimestamp)) {
+    return null
+  }
 
-  // Calculate difference in milliseconds, then convert to minutes
-  const diffMs = raceStart.getTime() - now.getTime()
-  return Math.round(diffMs / (1000 * 60))
+  const diffMs = raceStartTimestamp - Date.now()
+  return diffMs / (1000 * 60)
 }
 
 /**
@@ -185,7 +186,10 @@ export function createExtendedRaceWindow(baseHours: number = 1): {
  * @param {string} raceStatus - Current race status
  * @returns {number} Minutes until race start (accurate for DST)
  */
-export function calculateDstAwareMinutesToStart(raceStartTimeIso: string, raceStatus?: string): number | null {
+export function calculateDstAwareMinutesToStart(
+  raceStartTimeIso: string,
+  raceStatus?: string
+): number | null {
   if (!raceStartTimeIso) return null
 
   // Handle completed races

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -58,12 +58,14 @@ The daily data import is now handled by three sequential functions with 10-minut
   - Mathematical validation of pool sums and percentages
   - Dual-phase polling: early morning baseline capture + high-frequency critical periods
   - Server-heavy processing with pre-calculated incremental amounts
-- **Dynamic Intervals:**
-  - T-65m+: 5-minute intervals (baseline capture)
-  - T-30m to T-5m: 1-minute intervals
-  - T-5m to T-3m: 30-second intervals
-  - T-3m to Start: 15-second intervals
-  - Post-start: 15-second intervals until Final
+- **Dynamic Intervals (v4.8 aligned):**
+  - T-65m+: 30-minute baseline cadence (15 minutes with double-frequency override)
+  - T-60m to T-5m: 2.5-minute active cadence (75 seconds with double-frequency override)
+  - T-5m to Final: 30-second critical cadence (15 seconds with double-frequency override)
+  - Post-final statuses: Polling halts entirely to conserve capacity
+- **Cadence Controls:**
+  - Client/UI mirrors these windows via `calculatePollingIntervalMs`
+  - Environment toggles: `NEXT_PUBLIC_DOUBLE_POLLING_FREQUENCY`, `DOUBLE_POLLING_FREQUENCY`, `NEXT_PUBLIC_POLLING_ENABLED`, `NEXT_PUBLIC_POLLING_DEBUG_MODE`, `NEXT_PUBLIC_POLLING_TIMEOUT`
 
 #### master-race-scheduler (Scheduled, Autonomous Coordination)
 - **Specification:** s-1vcpu-512mb


### PR DESCRIPTION
## Summary
- align the client polling interval calculator with backend cadence windows and double-frequency overrides
- update the polling hook to stop on final statuses, resume when races reactivate, and recalculate intervals on status/start-time shifts
- document cadence environment toggles, refine timezone helpers, and expand interval unit tests

## Testing
- npx tsc --noEmit
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d897bd5a348320919bc1a1b7c4b1f0